### PR TITLE
Update SignedDecimalMath.sol

### DIFF
--- a/contracts/synthetix/SignedDecimalMath.sol
+++ b/contracts/synthetix/SignedDecimalMath.sol
@@ -139,7 +139,7 @@ library SignedDecimalMath {
    */
   function divideDecimal(int x, int y) internal pure returns (int) {
     /* Reintroduce the UNIT factor that will be divided out by y. */
-    return (x * UNIT) * y;
+    return (x * UNIT) / y;
   }
 
   /**


### PR DESCRIPTION
Hi, I was going through the library and I think there is a small bug here. according to the comments it should be (x * UNIT ) / y in L142

https://github.com/lyra-finance/lyra-protocol/blob/1207dea2195a8f5484dd465d6b7c8312d5d57186/contracts/synthetix/SignedDecimalMath.sol#L142