### PR TITLE
update: typechain to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/contracts": "^3.3.0",
-    "@typechain/ethers-v5": "^6.0.1",
+    "@typechain/ethers-v5": "^10.1.0",
+    "@typechain/hardhat": "^6.1.2",
     "@types/better-sqlite3": "^7.4.0",
     "@types/chai": "^4.2.14",
     "@types/mathjs": "^6.0.11",
@@ -56,7 +57,6 @@
     "hardhat": "^2.2.1",
     "hardhat-contract-sizer": "^2.0.3",
     "hardhat-gas-reporter": "^1.0.4",
-    "hardhat-typechain": "^0.3.5",
     "husky": "4.3.8",
     "lint-staged": "^10.5.4",
     "mathjs": "^9.3.0",
@@ -71,7 +71,7 @@
     "solidity-docgen": "^0.5.13",
     "ts-generator": "^0.1.1",
     "ts-node": "^9.1.1",
-    "typechain": "^4.0.3",
+    "typechain": "^8.1.0",
     "typescript": "^4.1.3"
   },
   "husky": {


### PR DESCRIPTION
Currently, the version of `typechain` that `@lyrafinance/protocol` uses conflicts with other `typechain` versions that are installed.

Updating `typechain` to the latest version should get rid of this error

## Workaround
* If you have `typechain` already installed, you can avoid the npm error by installing `@lyrafinance/protocol` using `npm i --legacy-peer-deps`

## Notes
* I can't test this at the moment bc i have so internet 😅
