### PR TITLE
[Newport op] Remove non-existent files from lyraContractPaths and fixed README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,15 @@ async function main() {
     iterations: 3;
     minTotalCost: toBN("0");
     maxTotalCost?: toBN("250");
-  };)
+  });
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch(error => {
+    console.error(error);
+    process.exit(1);
+  });
 ```
 
 ```bash

--- a/test/utils/package/index-paths.ts
+++ b/test/utils/package/index-paths.ts
@@ -12,9 +12,7 @@ export const lyraContractPaths = [
   '@lyrafinance/protocol/contracts/OptionGreekCache.sol',
   '@lyrafinance/protocol/contracts/OptionMarket.sol',
   '@lyrafinance/protocol/contracts/OptionToken.sol',
-  '@lyrafinance/protocol/contracts/ShortPoolHedger.sol',
   '@lyrafinance/protocol/contracts/ShortCollateral.sol',
-  '@lyrafinance/protocol/contracts/SynthetixAdapter.sol',
 
   // interfaces
   '@lyrafinance/protocol/contracts/interfaces/ILiquidityPool.sol',
@@ -53,20 +51,11 @@ export const lyraContractPaths = [
   '@lyrafinance/protocol/contracts/test-helpers/MathTest.sol',
   '@lyrafinance/protocol/contracts/test-helpers/MockAggregatorV2V3.sol',
   '@lyrafinance/protocol/contracts/test-helpers/Path.sol',
-  '@lyrafinance/protocol/contracts/test-helpers/TestAddressResolver.sol',
-  '@lyrafinance/protocol/contracts/test-helpers/TestCollateralShort.sol',
   '@lyrafinance/protocol/contracts/test-helpers/TestCurve.sol',
-  '@lyrafinance/protocol/contracts/test-helpers/TestDelegateApprovals.sol',
-  '@lyrafinance/protocol/contracts/test-helpers/TestDelegateApprovals.sol',
   '@lyrafinance/protocol/contracts/test-helpers/TestERC20.sol',
   '@lyrafinance/protocol/contracts/test-helpers/TestERC20Fail.sol',
   '@lyrafinance/protocol/contracts/test-helpers/TestERC20SetDecimals.sol',
-  '@lyrafinance/protocol/contracts/test-helpers/TestExchanger.sol',
-  '@lyrafinance/protocol/contracts/test-helpers/TestExchangeRates.sol',
   '@lyrafinance/protocol/contracts/test-helpers/TestFaucet.sol',
-  '@lyrafinance/protocol/contracts/test-helpers/TestSwapRouter.sol',
-  '@lyrafinance/protocol/contracts/test-helpers/TestSynthetix.sol',
-  '@lyrafinance/protocol/contracts/test-helpers/TestSynthetixReturnZero.sol',
 
   // @openzeppelin
   'openzeppelin-contracts-upgradeable-4.5.1/access/OwnableUpgradeable.sol',


### PR DESCRIPTION
Things done in this PR:
- Removed non-existent files from `lyraContractPaths` 82c7e18cc9163b707ef3248c4f4c3c2f1e5a142a. The `TestSytem` doesn't compile without this change.
- Fixed a script in `README.md` d9114526d718b9f520954b006b9bebe07a63260d. I fixed a syntax error and called the main function. 